### PR TITLE
Add dockerfile and Makefile, use K 6.3.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ module-imports-graph.svg
 tests/specs/verification-kompiled/*
 .krun*
 kimp/.kprove*
+docker/.image

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Latest versions at the time of writing
+K_VERSION   ?= 6.3.19
+PYK_VERSION ?= 0.1.664
+
+default: help
+
+help:
+	@echo "Please read the Makefile."
+
+.phony: docker
+docker: docker/.image
+
+docker/.image: docker/Dockerfile.k+pyk
+	docker build \
+		--build-arg K_VERSION=$(K_VERSION) \
+		--build-arg PYK_VERSION=$(PYK_VERSION) \
+		-f $< -t runtimeverification/imp-semantics-k:$(K_VERSION) .
+	touch $@

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ build-llvm: have-k $(TARGETS:=-llvm)
 build-haskell: have-k $(TARGETS:=-haskell)
 
 .build/%-kompiled-llvm: kimp/k-src/%.k $(K_SOURCES)
-	$(KOMPILE) --output-definition $@-llvm $< -I kimp/k-src --backend llvm
+	$(KOMPILE) --output-definition $@ $< -I kimp/k-src --backend llvm
 .build/%-kompiled-haskell: kimp/k-src/%.k $(K_SOURCES)
-	$(KOMPILE) --output-definition $@-haskell $< -I kimp/k-src --backend haskell
+	$(KOMPILE) --output-definition $@ $< -I kimp/k-src --backend haskell
 
 .phony: have-k
 have-k: FOUND_VERSION = $(shell $(KOMPILE) --version \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Latest versions at the time of writing
 K_VERSION   ?= 6.3.19
 PYK_VERSION ?= 0.1.664
+KOMPILE     ?= $(shell which kompile)
 
 default: help
 
@@ -16,3 +17,27 @@ docker/.image: docker/Dockerfile.k+pyk
 		--build-arg PYK_VERSION=$(PYK_VERSION) \
 		-f $< -t runtimeverification/imp-semantics-k:$(K_VERSION) .
 	touch $@
+
+K_SOURCES = $(wildcard kimp/k-src/*.k)
+TARGETS   = $(patsubst %.k,.build/%-kompiled,$(notdir $(K_SOURCES)))
+
+build: build-llvm build-haskell
+
+build-llvm: have-k $(TARGETS:=-llvm)
+build-haskell: have-k $(TARGETS:=-haskell)
+
+.build/%-kompiled-llvm: kimp/k-src/%.k $(K_SOURCES)
+	$(KOMPILE) --output-definition $@-llvm $< -I kimp/k-src --backend llvm
+.build/%-kompiled-haskell: kimp/k-src/%.k $(K_SOURCES)
+	$(KOMPILE) --output-definition $@-haskell $< -I kimp/k-src --backend haskell
+
+.phony: have-k
+have-k: FOUND_VERSION = $(shell $(KOMPILE) --version \
+				  | sed -n -e 's/^K version: *v\?\([0-9.]*\)$$/\1/p')
+have-k:
+	@[ ! -z "$(KOMPILE)" ] || \
+		(echo "K compiler (kompile) not found (use variable KOMPILE to override)."; exit 1)
+	@[ ! -z "$(FOUND_VERSION)" ] || \
+		(echo "Unable to determine K compiler ($(KOMPILE)) version."; exit 1)
+	@[ "$(K_VERSION)" = "$(FOUND_VERSION)" ] || \
+		echo "Unexpected kompile version $(FOUND_VERSION) (expected $(K_VERSION)). Trying anyway..."

--- a/docker/Dockerfile.k+pyk
+++ b/docker/Dockerfile.k+pyk
@@ -1,0 +1,50 @@
+ARG K_VERSION
+
+FROM runtimeverificationinc/kframework-k:ubuntu-jammy-$K_VERSION
+
+ARG K_VERSION
+ARG PYK_VERSION
+
+# create non-root user and adjust UID:GID on start-up
+# see https://github.com/boxboat/fixuid
+RUN addgroup --gid 1000 k-group && \
+    adduser -uid 1000 --ingroup k-group --home /home/k-user --shell /bin/sh --disabled-password --gecos "" k-user
+RUN apt install curl && \
+    USER=k-user && \
+    GROUP=k-group && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+USER k-user:k-group
+WORKDIR /home/k-user
+ENV PATH=/home/k-user/.local/bin:$PATH force_color_prompt=yes
+
+# install poetry and pyk (ours! not the one in pip)
+RUN pip install poetry && \
+    curl -SsL https://github.com/runtimeverification/pyk/archive/refs/tags/v${PYK_VERSION}.tar.gz | tar -C /home/k-user -xzf - && \
+    cd pyk-${PYK_VERSION} && \
+    make build && \
+    pip install dist/*.whl
+
+
+ENTRYPOINT ["fixuid", "-q"]
+
+CMD printf "%s\n" \
+    "Welcome to the K framework" \
+    "" \
+    "This docker image provides a K-framework installation with the following programs:" \
+    " * kompile" \
+    " * krun" \
+    " * kprove" \
+    " * kast" \
+    " * K backend tools (kore-*)" \
+    "" \
+    "as well as a pre-installed pyk library to interact with K programmatically." \
+    "" \
+    "To use this docker image, start a container with an interactive shell and" \
+    "a working directory with your K definition mounted into it, like so:" \
+    "" \
+    'user@host$ docker run --rm -it -v "$PWD":/home/k-user/workspace -u $(id -u):$(id -g) <docker-image> /bin/bash' \
+    ""

--- a/docker/Dockerfile.k+pyk
+++ b/docker/Dockerfile.k+pyk
@@ -19,7 +19,10 @@ RUN apt install curl && \
     printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
 USER k-user:k-group
 WORKDIR /home/k-user
-ENV PATH=/home/k-user/.local/bin:$PATH force_color_prompt=yes
+ENV K_VERSION=${K_VERSION} \
+    PYK_VERSION=${PYK_VERSION} \
+    PATH=/home/k-user/.local/bin:$PATH \
+    force_color_prompt=yes
 
 # install poetry and pyk (ours! not the one in pip)
 RUN pip install poetry && \


### PR DESCRIPTION
* added Dockerfile to provide a K installation (`v6.3.19` by default) and `pyk` installation (`0.1.644` by default)
* added a basic `Makefile`
  - `make docker` builds the docker image 
  - `make build` 
    - checks that  `kompile` is usable, warns if the version is not the expected one
    - then builds all K files found in `kimp/k-src` , outputting into `.build/<file>-kompiled-<backend>`, with both `llvm` and `haskell` backend
  - make `build-llvm` and `make build-haskell` build for just the backend indicated
