### PR TITLE
Clean-up and extend `kimp` CLI

### DIFF
--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from argparse import ArgumentParser
 from pathlib import Path
-import os
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Final
 
@@ -22,11 +22,11 @@ _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
 def find_definiton_dir(target: str) -> Path:
-    '''
+    """
     Find the kompiled definiton directory for a `kbuild` target target:
     * if the KIMP_${target.upper}_DIR is set --- use that
     * otherwise ask `kbuild`
-    '''
+    """
 
     def kbuild_definition_dir(target: str) -> Path:
         proc_result = subprocess.run(
@@ -51,14 +51,14 @@ def find_definiton_dir(target: str) -> Path:
 
 
 def find_k_src_dir() -> Path:
-    '''
+    """
     A heuristic way to find the the k-src dir with the K sources is located:
     * if KIMP_K_SRC environment variable is set --- use that
     * otherwise, use ./k-src and hope it works
-    '''
-    ksrc_dir = os.environ.get(f'KIMP_K_SRC')
-    if ksrc_dir:
-        ksrc_dir = Path(ksrc_dir).resolve()
+    """
+    ksrc_dir_str = os.environ.get('KIMP_K_SRC')
+    if ksrc_dir_str is not None:
+        ksrc_dir = Path(ksrc_dir_str).resolve()
     else:
         ksrc_dir = Path('./k-src')
     return ksrc_dir
@@ -134,7 +134,7 @@ def exec_prove(
         definition_dir = str(find_definiton_dir('haskell'))
     k_src_dir = str(find_k_src_dir())
 
-    kimp = KIMP(definition_dir, definition_dir)
+    kimp = KIMP(definition_dir, definition_dir, None)
 
     try:
         kimp.prove(
@@ -167,7 +167,7 @@ def exec_show(
     **kwargs: Any,
 ) -> None:
     definition_dir = str(find_definiton_dir('haskell'))
-    kimp = KIMP(definition_dir, definition_dir)
+    kimp = KIMP(definition_dir, definition_dir, None)
     kimp.show_kcfg(spec_module, claim_id)
 
 
@@ -178,7 +178,7 @@ def exec_view(
     **kwargs: Any,
 ) -> None:
     definition_dir = str(find_definiton_dir('haskell'))
-    kimp = KIMP(definition_dir, definition_dir)
+    kimp = KIMP(definition_dir, definition_dir, None)
     kimp.view_kcfg(spec_module, claim_id)
 
 

--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -223,31 +223,6 @@ def create_argument_parser() -> ArgumentParser:
 
     parser = ArgumentParser(prog='kimp', description='KIMP command line tool')
     command_parser = parser.add_subparsers(dest='command', required=True, help='Command to execute')
-    # Parse
-    parse_subparser = command_parser.add_parser('parse', help='Parse a .imp file', parents=[shared_args])
-    parse_subparser.add_argument(
-        'input_file',
-        type=file_path,
-        help='Path to .imp file',
-    )
-    parse_subparser.add_argument(
-        '--input',
-        dest='input',
-        type=str,
-        default='program',
-        help='Input mode',
-        choices=['program', 'binary', 'json', 'kast', 'kore'],
-        required=False,
-    )
-    parse_subparser.add_argument(
-        '--output',
-        dest='output',
-        type=str,
-        default='kore',
-        help='Output mode',
-        choices=['pretty', 'program', 'json', 'kore', 'kast', 'none'],
-        required=False,
-    )
 
     # Run
     run_subparser = command_parser.add_parser('run', help='Run an IMP program', parents=[shared_args])
@@ -277,78 +252,14 @@ def create_argument_parser() -> ArgumentParser:
         'prove', help='Prove a K claim', parents=[shared_args, spec_file_shared_args, claim_shared_args, explore_args]
     )
 
-    # Summarize
-    _ = command_parser.add_parser(
-        'summarize',
-        help='Prove a K claim',
-        parents=[shared_args, spec_file_shared_args, claim_shared_args, explore_args],
-    )
-
-    # BMC Prove
-    bmc_prove_subparser = command_parser.add_parser(
-        'bmc-prove',
-        help='Prove a K claim with the Bounded Model-Checker',
-        parents=[shared_args, spec_file_shared_args, claim_shared_args, explore_args],
-    )
-    bmc_prove_subparser.add_argument(
-        '--bmc-depth',
-        type=int,
-        default=1,
-        help='Model checking bound',
-    )
-
-    # Refute node
-    refute_node_subparser = command_parser.add_parser(
-        'refute-node', help='Refute a node as infeasible', parents=[shared_args, claim_shared_args]
-    )
-    refute_node_subparser.add_argument(
-        '--node',
-        dest='node',
-        type=str,
-        help='node short hash',
-    )
-
-    # show refutation
-    show_refutation_subparser = command_parser.add_parser(
-        'show-refutation',
-        help='Display the equality proof of a node refutation',
-        parents=[shared_args, claim_shared_args],
-    )
-    show_refutation_subparser.add_argument(
-        '--node',
-        dest='node',
-        type=str,
-        help='node short hash',
-    )
-
-    # EQ prove
-    eq_prove_subparser = command_parser.add_parser('eq-prove', help='Prove an equality', parents=[shared_args])
-    eq_prove_subparser.add_argument(
-        'proof_id',
-        type=str,
-        help='Id of a JSON-serialized proof',
-    )
-
     # KCFG show
-    kcfg_show_subparser = command_parser.add_parser(
-        'show', help="Display the proof's symbolic execution tree as text", parents=[shared_args, claim_shared_args]
-    )
-    kcfg_show_subparser.add_argument(
-        '--to-module',
-        default=False,
-        action='store_true',
-        help='Display a K module containing the KCFG thus far.',
-    )
-    kcfg_show_subparser.add_argument(
-        '--inline-nodes',
-        default=False,
-        action='store_true',
-        help='Display states inline with KCFG nodes.',
+    command_parser.add_parser(
+        'show', help="Display a proof's symbolic execution tree as text", parents=[shared_args, claim_shared_args]
     )
     # KCFG view
     command_parser.add_parser(
         'view',
-        help="Display the proof's symbolic execution tree in an intercative viewver",
+        help="Display a proof's symbolic execution tree in an intercative viewver",
         parents=[shared_args, claim_shared_args],
     )
 

--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -143,7 +143,7 @@ def exec_prove(
             raise
 
 
-def exec_show_kcfg(
+def exec_show(
     definition_dir: str,
     spec_module: str,
     claim_id: str,
@@ -154,7 +154,7 @@ def exec_show_kcfg(
     kimp.show_kcfg(spec_module, claim_id)
 
 
-def exec_view_kcfg(
+def exec_view(
     definition_dir: str,
     spec_module: str,
     claim_id: str,
@@ -331,7 +331,7 @@ def create_argument_parser() -> ArgumentParser:
 
     # KCFG show
     kcfg_show_subparser = command_parser.add_parser(
-        'show-kcfg', help='Display tree show of CFG', parents=[shared_args, claim_shared_args]
+        'show', help="Display the proof's symbolic execution tree as text", parents=[shared_args, claim_shared_args]
     )
     kcfg_show_subparser.add_argument(
         '--to-module',
@@ -345,15 +345,12 @@ def create_argument_parser() -> ArgumentParser:
         action='store_true',
         help='Display states inline with KCFG nodes.',
     )
-    # KCFG to dot
+    # KCFG view
     command_parser.add_parser(
-        'kcfg-to-dot',
-        help='Dump the given CFG for the proof as DOT for visualization.',
+        'view',
+        help="Display the proof's symbolic execution tree in an intercative viewver",
         parents=[shared_args, claim_shared_args],
     )
-
-    # KCFG view
-    command_parser.add_parser('view-kcfg', help='Display tree view of CFG', parents=[shared_args, claim_shared_args])
 
     return parser
 

--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -34,7 +34,7 @@ def find_definiton_dir(target: str) -> Path:
         )
         if proc_result.returncode:
             _LOGGER.critical(
-                f'Could not find kbuild definition for target {target}. Run kbuild kompile {target}, or specify --definition-dir.'
+                f'Could not find kbuild definition for target {target}. Run kbuild kompile {target}, or specify --definition.'
             )
             exit(proc_result.returncode)
         else:
@@ -171,7 +171,7 @@ def create_argument_parser() -> ArgumentParser:
     shared_args.add_argument('--verbose', '-v', default=False, action='store_true', help='Verbose output.')
     shared_args.add_argument('--debug', default=False, action='store_true', help='Debug output.')
     shared_args.add_argument(
-        '--definition-dir',
+        '--definition',
         dest='definition_dir',
         nargs='?',
         type=dir_path,

--- a/kimp/src/kimp/kimp.py
+++ b/kimp/src/kimp/kimp.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
-from pyk.kast.manip import remove_generated_cells, get_cell
-from pyk.kast.pretty import SymbolTable, paren
-from pyk.kcfg.kcfg import KCFG
 
+from pyk.kast.manip import get_cell, remove_generated_cells
+from pyk.kast.pretty import paren
 from pyk.kcfg.show import NodePrinter
 
 __all__ = ['KIMP']
@@ -16,7 +15,6 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Union, final
 
 from pyk.cli.utils import check_dir_path, check_file_path
-from pyk.cterm.cterm import CTerm
 from pyk.cterm.symbolic import CTermSymbolic
 from pyk.kast.inner import KApply, KSequence, KVariable
 from pyk.kast.manip import ml_pred_to_bool
@@ -24,13 +22,12 @@ from pyk.kcfg.explore import KCFGExplore
 from pyk.kcfg.semantics import KCFGSemantics
 from pyk.kore.kompiled import KompiledKore
 from pyk.kore.rpc import KoreClient, kore_server
-from pyk.ktool.kprint import gen_glr_parser
 from pyk.ktool.kprove import KProve
 from pyk.ktool.krun import KRun, KRunOutput, _krun
 from pyk.prelude.kbool import BOOL, notBool
-from pyk.prelude.ml import mlAnd, mlEqualsTrue
+from pyk.prelude.ml import mlEqualsTrue
 from pyk.proof.reachability import APRProof, APRProver
-from pyk.proof.show import APRProofNodePrinter, APRProofShow
+from pyk.proof.show import APRProofShow
 from pyk.proof.tui import APRProofViewer
 from pyk.utils import single
 
@@ -38,8 +35,11 @@ if TYPE_CHECKING:
     from subprocess import CompletedProcess
     from typing import Final
 
+    from pyk.cterm.cterm import CTerm
     from pyk.kast.inner import KInner
     from pyk.kast.outer import KDefinition
+    from pyk.kast.pretty import SymbolTable
+    from pyk.kcfg.kcfg import KCFG
     from pyk.kore.rpc import FallbackReason
     from pyk.ktool.kprint import KPrint
     from pyk.utils import BugReport
@@ -314,18 +314,18 @@ class KIMPNodePrinter(NodePrinter):
 
     def print_node(self, kcfg: KCFG, node: KCFG.Node) -> list[str]:
         ret_strs = super().print_node(kcfg, node)
-        config = get_cell(remove_generated_cells(node.cterm.config), "K_CELL")
-        env = get_cell(remove_generated_cells(node.cterm.config), "ENV_CELL")
+        config = get_cell(remove_generated_cells(node.cterm.config), 'K_CELL')
+        env = get_cell(remove_generated_cells(node.cterm.config), 'ENV_CELL')
         # pretty-print the configuration
         ret_strs += self.kimp.kprove.pretty_print(config).splitlines()
-        ret_strs += ["env:"]
+        ret_strs += ['env:']
         ret_strs += [
-            "  " + l.replace("( ", "").replace(" )", "") for l in self.kimp.kprove.pretty_print(env).splitlines()
+            '  ' + l.replace('( ', '').replace(' )', '') for l in self.kimp.kprove.pretty_print(env).splitlines()
         ]
         # pretty-print the constraints
         constraints = [ml_pred_to_bool(c) for c in node.cterm.constraints]
         if len(constraints) > 0:
-            ret_strs += ["constraints:"]
+            ret_strs += ['constraints:']
             for c in constraints:
-                ret_strs.append("  " + self.kimp.kprove.pretty_print(c))
+                ret_strs.append('  ' + self.kimp.kprove.pretty_print(c))
         return ret_strs


### PR DESCRIPTION
* rename `kimp view-kcfg` to `kimp view`, and `kimp show-kcfg` to `kimp show`.
* implement `kimp run --defintion`, allowing to pass, for example, the definition compiled from `expressions.k`
* Implement `kimp run --input-term`. In combination with the above options, that gives us the ability to do `kimp run --definition expressions-kompiled --input-term '1 + 2'.
* refactor input file positional argument of `kimp run` to be an option, i.e. instead of `kimp run FILENAME` we now have to write `kimp run --input-file FILENAME`. This allows us to make the `--input-file` and `input-term` mutually exclusive.