### PR TITLE
Improve pretty printing

### DIFF
--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -279,7 +279,7 @@ def create_argument_parser() -> ArgumentParser:
     # KCFG view
     command_parser.add_parser(
         'view',
-        help="Display a proof's symbolic execution tree in an intercative viewver",
+        help="Display a proof's symbolic execution tree in an intercative viewer",
         parents=[shared_args, claim_shared_args],
     )
 

--- a/kimp/src/kimp/__main__.py
+++ b/kimp/src/kimp/__main__.py
@@ -8,7 +8,7 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, Final
 
 from pyk.cli.utils import dir_path, file_path
-from pyk.ktool.kprint import KAstOutput, gen_glr_parser
+from pyk.ktool.kprint import KAstOutput
 from pyk.ktool.krun import KRunOutput
 
 from .kimp import KIMP
@@ -76,17 +76,8 @@ def exec_run(
 ) -> None:
     krun_output = KRunOutput[output.upper()]
 
-    imp_parser = None
-    if definition_dir is None:
-        definition_dir_path = find_target('llvm')
-        imp_parser = definition_dir_path / 'parser_Stmt_STATEMENTS-SYNTAX'
-        if not imp_parser.is_file():
-            imp_parser = gen_glr_parser(
-                imp_parser, definition_dir=definition_dir_path, module='STATEMENTS-SYNTAX', sort='Stmt'
-            )
-    else:
-        definition_dir_path = Path(definition_dir)
-    kimp = KIMP(definition_dir_path, definition_dir_path, imp_parser)
+    definition_dir_path = find_target('llvm') if definition_dir is None else Path(definition_dir)
+    kimp = KIMP(definition_dir_path, definition_dir_path)
 
     try:
         with NamedTemporaryFile(mode='w') as f:
@@ -123,7 +114,7 @@ def exec_prove(
         definition_dir = str(find_target('haskell'))
     k_src_dir = str(find_target('source') / 'imp-semantics')
 
-    kimp = KIMP(definition_dir, definition_dir, None)
+    kimp = KIMP(definition_dir, definition_dir)
 
     try:
         kimp.prove(
@@ -156,7 +147,7 @@ def exec_show(
     **kwargs: Any,
 ) -> None:
     definition_dir = str(find_target('haskell'))
-    kimp = KIMP(definition_dir, definition_dir, None)
+    kimp = KIMP(definition_dir, definition_dir)
     kimp.show_kcfg(spec_module, claim_id)
 
 
@@ -167,7 +158,7 @@ def exec_view(
     **kwargs: Any,
 ) -> None:
     definition_dir = str(find_target('haskell'))
-    kimp = KIMP(definition_dir, definition_dir, None)
+    kimp = KIMP(definition_dir, definition_dir)
     kimp.view_kcfg(spec_module, claim_id)
 
 

--- a/kimp/src/kimp/kdist/imp-semantics/expressions.k
+++ b/kimp/src/kimp/kdist/imp-semantics/expressions.k
@@ -12,9 +12,9 @@ module EXPRESSIONS-SYNTAX
   imports VALUE-SYNTAX
 
   syntax Expr     ::= Value
-                    | "(" Expr ")" [bracket]
+                    | "(" Expr ")" [bracket, format(%1%2%3)]
 
-  syntax Expr     ::= "-" Expr      [group(unary), strict, non-assoc]
+  syntax Expr     ::= "-" Expr      [group(unary), strict, non-assoc, format(%1%2)]
                     > left:
                       Expr "*" Expr [group(mul), seqstrict]
                     | Expr "/" Expr [group(mul), seqstrict]
@@ -29,7 +29,7 @@ module EXPRESSIONS-SYNTAX
                     | Expr "<=" Expr [group(comp), seqstrict, non-assoc]
                     | Expr "<"  Expr [group(comp), strict, non-assoc]
 
-  syntax Expr     ::= "!" Expr       [group(unary), strict, non-assoc]
+  syntax Expr     ::= "!" Expr       [group(unary), strict, non-assoc, format(%1%2)]
                     > Expr "&&" Expr [group(bool), seqstrict, left]
                     > Expr "||" Expr [group(bool), seqstrict, left]
 

--- a/kimp/src/kimp/kdist/imp-semantics/statements.k
+++ b/kimp/src/kimp/kdist/imp-semantics/statements.k
@@ -5,15 +5,15 @@ module STATEMENTS-SYNTAX
   imports EXPRESSIONS-SYNTAX
   imports VARIABLES-SYNTAX
 
-  syntax Stmt ::= Id "=" Expr ";"                    [strict(2)]
-                | "if" "(" Expr ")" Stmt "else" Stmt [strict(1), avoid] // dangling else
-                | "if" "(" Expr ")" Stmt
-                | "while" "(" Expr ")" Stmt          // not strict!
+  syntax Stmt ::= Id "=" Expr ";"                    [strict(2), format(%1 %2 %3%4)]
+                | "if" "(" Expr ")" Stmt "else" Stmt [strict(1), avoid, format(%1 %2%3%4% %5 %6 %7)] // dangling else
+                | "if" "(" Expr ")" Stmt             [format(%1 %2%3%4 %5)]
+                | "while" "(" Expr ")" Stmt          [format(%1 %2%3%4 %5)] // not strict!
                 // blocks of statements
-                | "{" Stmt "}"
-                | "{" "}"
+                | "{" Stmt "}"                       [format(%1%i%n%2%d%n%3)]
+                | "{" "}"                            [format(%1%2)]
                 > right:
-                  Stmt Stmt
+                  Stmt Stmt                          [format(%1%n%2)]
 endmodule
 
 module STATEMENTS-RULES

--- a/kimp/src/kimp/kimp.py
+++ b/kimp/src/kimp/kimp.py
@@ -88,10 +88,9 @@ class ImpSemantics(KCFGSemantics):
 class KIMP:
     llvm_dir: Path
     haskell_dir: Path
-    imp_parser: Path
     proof_dir: Path
 
-    def __init__(self, llvm_dir: str | Path, haskell_dir: str | Path, imp_parser: Path | None):
+    def __init__(self, llvm_dir: str | Path, haskell_dir: str | Path):
         llvm_dir = Path(llvm_dir)
         check_dir_path(llvm_dir)
 
@@ -103,9 +102,11 @@ class KIMP:
 
         object.__setattr__(self, 'llvm_dir', llvm_dir)
         object.__setattr__(self, 'haskell_dir', haskell_dir)
-        if imp_parser is not None:
-            object.__setattr__(self, 'imp_parser', imp_parser)
         object.__setattr__(self, 'proof_dir', proof_dir)
+
+    @cached_property
+    def imp_parser(self) -> Path:
+        return self.llvm_dir / 'parser_PGM'
 
     @cached_property
     def kprove(self) -> KProve:
@@ -136,7 +137,7 @@ class KIMP:
                 check=check,
                 depth=depth,
                 pipe_stderr=True,
-                pmap={'PGM': str(self.imp_parser)} if hasattr(self, 'imp_parser') else {},
+                pmap={'PGM': str(self.imp_parser)},
             )
 
         def preprocess_and_run(program_file: Path, temp_file: Path) -> CompletedProcess:

--- a/kimp/src/kimp/kimp.py
+++ b/kimp/src/kimp/kimp.py
@@ -21,6 +21,7 @@ from pyk.kast.outer import read_kast_definition
 from pyk.kcfg.explore import KCFGExplore
 from pyk.kcfg.semantics import KCFGSemantics
 from pyk.kore.rpc import KoreClient, kore_server
+from pyk.ktool.claim_loader import ClaimLoader
 from pyk.ktool.kprove import KProve
 from pyk.ktool.krun import KRun, KRunOutput, _krun
 from pyk.proof.reachability import APRProof, APRProver
@@ -173,7 +174,7 @@ class KIMP:
     ) -> None:
         include_dirs = [Path(include) for include in includes]
 
-        claims = self.kprove.get_claims(
+        claims = ClaimLoader(self.kprove).load_claims(
             Path(spec_file), spec_module_name=spec_module, claim_labels=[claim_id], include_dirs=include_dirs
         )
         claim = single(claims)

--- a/kimp/src/kimp/kimp.py
+++ b/kimp/src/kimp/kimp.py
@@ -280,7 +280,6 @@ def legacy_explore(
                     definition=kprint.definition,
                 )
                 yield KCFGExplore(
-                    # kore_client=client,
                     kcfg_semantics=kcfg_semantics,
                     id=id,
                     cterm_symbolic=cterm_symbolic,

--- a/kimp/src/kimp/kimp.py
+++ b/kimp/src/kimp/kimp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pyk.kast.pretty import paren
 from pyk.kcfg.show import NodePrinter
 
 __all__ = ['KIMP']
@@ -33,7 +32,6 @@ if TYPE_CHECKING:
     from typing import Final
 
     from pyk.cterm.cterm import CTerm
-    from pyk.kast.pretty import SymbolTable
     from pyk.kcfg.kcfg import KCFG, KCFGExtendResult
     from pyk.kore.rpc import FallbackReason
     from pyk.ktool.kprint import KPrint
@@ -110,10 +108,7 @@ class KIMP:
 
     @cached_property
     def kprove(self) -> KProve:
-        kprove = KProve(
-            definition_dir=self.haskell_dir, use_directory=self.proof_dir, patch_symbol_table=KIMP._patch_symbol_table
-        )
-        return kprove
+        return KProve(definition_dir=self.haskell_dir, use_directory=self.proof_dir)
 
     @cached_property
     def krun(self) -> KRun:
@@ -229,10 +224,6 @@ class KIMP:
             proof,
         )
         print('\n'.join(res_lines))
-
-    @classmethod
-    def _patch_symbol_table(cls, symbol_table: SymbolTable) -> None:
-        symbol_table['_Map_'] = paren(lambda m1, m2: m1 + '\n' + m2)
 
 
 @contextmanager


### PR DESCRIPTION
* Add the `format` attribute to expression and statement productions
* Use `Formatter` for pretty printing nodes
* Use `ClaimLoader` for loading claims
* Small cleanups